### PR TITLE
Add (failing) test for cyclic object persistence

### DIFF
--- a/test/vuex-mockstorage-cyclic.spec.ts
+++ b/test/vuex-mockstorage-cyclic.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Created by rossng on 02/04/2018.
+ */
+import { Store } from 'vuex'
+import Vuex = require('vuex')
+import Vue = require('vue')
+import VuexPersistence, { MockStorage } from '../dist'
+import { assert, expect, should } from 'chai'
+
+Vue.use(Vuex)
+const mockStorage = new MockStorage()
+const vuexPersist = new VuexPersistence<any, any>({
+  storage: mockStorage
+})
+
+const store = new Store<any>({
+  state: {
+    cyclicObject: null
+  },
+  mutations: {
+    storeCyclicObject(state, payload) {
+      state.cyclicObject = payload
+    }
+  },
+  plugins: [vuexPersist.plugin]
+})
+const getSavedStore = () => JSON.parse(mockStorage.getItem('vuex'))
+
+describe('Storage: MockStorage, Test: cyclic object', () => {
+  it('should persist cyclic object', () => {
+    let cyclicObject: any = { foo: 10 }
+    cyclicObject.bar = cyclicObject
+    store.commit('storeCyclicObject', cyclicObject)
+    expect(getSavedStore().cyclicObject.foo).to.equal(10)
+  })
+})


### PR DESCRIPTION
This PR adds a test for persisting cyclic objects, which currently fails with the following message:

```
 1) Storage: MockStorage, Test: cyclic object
       should persist cyclic object:
     TypeError: Converting circular structure to JSON
      at JSON.stringify (<anonymous>)
      at VuexPersistence.saveState (src\index.ts:194:22)
      at C:\Users\ross\Documents\Development\JavaScript\vuex-persist\src\index.ts:214:18
      at C:\Users\ross\Documents\Development\JavaScript\vuex-persist\node_modules\vuex\dist\vuex.common.js:394:53
      at Array.forEach (<anonymous>)
      at Store.commit (node_modules\vuex\dist\vuex.common.js:394:21)
      at Store.boundCommit [as commit] (node_modules\vuex\dist\vuex.common.js:337:19)
      at Context.<anonymous> (test\vuex-mockstorage-cyclic.spec.ts:33:11)
```