### PR TITLE
add shared mutations across stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ A Typescript-ready [Vuex](https://vuex.vuejs.org/) plugin that enables
 you to save the state of your app to a persisted storage like
 Cookies or localStorage.
 
+This fork provide you a shared mutations system as extra feature.
+You can keep synchronized the state of your app across multiple windows
+or multiple store instances. It is really usefull when you develop
+a web extension and don't want to worry about different contexts.
+
 [![GitHub stars](https://img.shields.io/github/stars/championswimmer/vuex-persist.svg?style=social&label=%20vuex-persist)](http://github.com/championswimmer/vuex-persist)
 [![npm](https://img.shields.io/npm/v/vuex-persist.svg?colorB=dd1100)](http://npmjs.com/vuex-persist)
 [![npm](https://img.shields.io/npm/dw/vuex-persist.svg?colorB=fc4f4f)](http://npmjs.com/vuex-persist)
@@ -257,7 +262,7 @@ In strict mode, we cannot use `store.replaceState` so instead we use a mutation
 You'll need to keep in mind to add the **`RESTORE_MUTATION`** to your mutations
 See example below
 
-To configure with strict mode support - 
+To configure with strict mode support -
 
 ```typescript
 import Vue from 'vue'
@@ -347,11 +352,10 @@ what you can do to _find out_ when store has restored.
 ## Unit Testing
 
 ### Jest
-When testing with Jest, you might find this error - 
+When testing with Jest, you might find this error -
 ```
 TypeError: Cannot read property 'getItem' of undefined
 ```
 
 This is because there is no localStorage in Jest. You can add the following Jest plugins to solve this
 https://www.npmjs.com/package/jest-localstorage-mock
-

--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@ A Typescript-ready [Vuex](https://vuex.vuejs.org/) plugin that enables
 you to save the state of your app to a persisted storage like
 Cookies or localStorage.
 
-This fork provide you a shared mutations system as extra feature.
-You can keep synchronized the state of your app across multiple windows
-or multiple store instances. It is really usefull when you develop
-a web extension and don't want to worry about different contexts.
-
 [![GitHub stars](https://img.shields.io/github/stars/championswimmer/vuex-persist.svg?style=social&label=%20vuex-persist)](http://github.com/championswimmer/vuex-persist)
 [![npm](https://img.shields.io/npm/v/vuex-persist.svg?colorB=dd1100)](http://npmjs.com/vuex-persist)
 [![npm](https://img.shields.io/npm/dw/vuex-persist.svg?colorB=fc4f4f)](http://npmjs.com/vuex-persist)
@@ -46,6 +41,7 @@ a web extension and don't want to worry about different contexts.
  - 🎗 NEW IN V1.0.0
     - Support localForage and other Promise based stores
     - Fix late restore of state for localStorage
+    - Share mutations across multiple windows
  - Automatically save store on mutation.
  - Choose which mutations trigger store save, and which don't, using `filter` function
  - Works perfectly with modules in store
@@ -127,6 +123,9 @@ Here are the properties, and what they mean -
 | modules        | string[]                                  | List of modules you want to persist. (Do not write your own reducer if you want to use this)      |
 | asyncStorage   | boolean                                   | Denotes if the store uses Promises (like localforage) or not <br>_**Default: false**_
 | supportCircular| boolean                                   | Denotes if the state has any circular references to itself (state.x === state) |
+| keyMutation  	 | string                             	     | The key to store the mutation to share in the storage <br>_**Default:'vuex-shared-mutation'**_                                                                           |
+| sharedMutations| string[]                                 | List of mutations you want to share with multiple stores <br>_**Restriction: shared mutations must be in a VuexPersistence instance with localStorage provider**_               |
+| filterShared 	 | function<br> (mutation) => boolean     	| Shared mutation filter. Look at `mutation.type` and return true <br>for only those ones which you want to be replicated. <br> Default returns true for all mutations in sharedMutations 	|
 
 ### Usage Notes
 

--- a/src/PersistOptions.ts
+++ b/src/PersistOptions.ts
@@ -39,6 +39,11 @@ export interface PersistOptions<S> {
   key?: string
 
   /**
+   * Key to use to save the mutation to share into the storage
+   */
+  keyMutation?: string
+
+  /**
    * Method to filter which mutations will trigger state saving
    * Be default returns true for all mutations.
    * Check mutations using <code>mutation.type</code>

--- a/src/PersistOptions.ts
+++ b/src/PersistOptions.ts
@@ -47,6 +47,21 @@ export interface PersistOptions<S> {
   filter?: (mutation: Payload) => boolean
 
   /**
+   * Method to filter which mutations will trigger mutation sharing
+   * Be default, we share mutations in {@link PersistOptions.sharedMutations}
+   * Check mutations using <code>mutation.type</code>
+   * @param mutation object of type {@link Payload}
+   */
+  filterShared?: (mutation: Payload) => boolean
+
+  /**
+   * Names of mutations that you want to persist.
+   * If you create your custom {@link PersistOptions.filterShared} function,
+   * then you will have to handle this argument.
+   */
+  sharedMutations?: string[]
+
+  /**
    * Names of modules that you want to persist.
    * If you create your custom {@link PersistOptions.reducer} function,
    * then that will override filter behaviour, not this argument

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,10 +272,7 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
         }
 
         this.subscriber(store)((mutation: MutationPayload, state: S) => {
-          // console.log('subscriber')
-          // console.log(mutation)
           if (this.committing) return
-          // console.log('subscriber not committing')
 
           try {
             if (this.filterShared(mutation)) {
@@ -291,12 +288,13 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
         })
 
         if (options.sharedMutations != null || options.filterShared != null) {
+
+          /**
+           * localStorage version of event listener for shared mutations
+           */
           window.addEventListener('storage', event => {
             if (event.newValue === null) return;
             if (event.key !== this.keyMutation) return;
-
-            // console.log('event listener')
-            // console.log(event)
 
             try {
               const mutation = JSON.parse(event.newValue)
@@ -309,6 +307,7 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
               this.committing = false;
             }
           })
+
         }
 
         this.subscribed = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,10 +255,6 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
                   : JSON.stringify(mutation) as any
                 )
             )
-            &&
-            (storage).removeItem(
-              key
-            )
           )
       )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -242,8 +242,7 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
 
       /**
        * Sync {@link #VuexPersistence.saveMutation} implementation
-       * @type {((key: string, mutation: MutationPayload, storage?: Storage) =>
-       *     (Promise<void> | void)) | ((key: string, mutation: MutationPayload, storage?: Storage) => Promise<void>)}
+       * @type {((key: string, mutation: MutationPayload, storage?: Storage) => Promise<void>)}
        */
       this.saveMutation = ((key: string, mutation: MutationPayload, storage: Storage) =>
           (

--- a/src/index.ts
+++ b/src/index.ts
@@ -282,32 +282,37 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
               this.saveState(this.key, this.reducer(state), this.storage)
             }
           } catch (error) {
-            console.error('[vuex-persist] Unable to use setItem on localStorage');
+            console.error('[vuex-persist] Unable to use setItem');
             console.error(error);
           }
         })
 
         if (options.sharedMutations != null || options.filterShared != null) {
 
-          /**
-           * localStorage version of event listener for shared mutations
-           */
-          window.addEventListener('storage', event => {
-            if (event.newValue === null) return;
-            if (event.key !== this.keyMutation) return;
+          if (typeof window === 'undefined' || !window.localStorage) {
+            console.error('[vuex-persist] Shared mutations must be used in localStorage')
+          } else {
 
-            try {
-              const mutation = JSON.parse(event.newValue)
-              this.committing = true;
-              store.commit(mutation.type, mutation.payload);
-            } catch (error) {
-              console.error('[vuex-persist] Unable to parse shared mutation data');
-              console.error(event.newValue, error);
-            } finally {
-              this.committing = false;
-            }
-          })
+            /**
+            * localStorage version of event listener for shared mutations
+            */
+            window.addEventListener('storage', event => {
+              if (event.newValue === null) return;
+              if (event.key !== this.keyMutation) return;
 
+              try {
+                const mutation = JSON.parse(event.newValue)
+                this.committing = true;
+                store.commit(mutation.type, mutation.payload);
+              } catch (error) {
+                console.error('[vuex-persist] Unable to parse shared mutation data');
+                console.error(event.newValue, error);
+              } finally {
+                this.committing = false;
+              }
+            })
+
+          }
         }
 
         this.subscribed = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
   public saveMutation: (key: string, mutation: MutationPayload, storage?: AsyncStorage | Storage) => Promise<void> | void
   public reducer: (state: S) => {}
   public key: string
+  public keyMutation: string
   public filter: (mutation: Payload) => boolean
   public filterShared: (mutation: Payload) => boolean
   public sharedMutations: string[]
@@ -41,7 +42,6 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
    * A boolean that verify if this is a shared commit
    */
   public committing: boolean
-  public mutationKey: string
 
   // tslint:disable-next-line:variable-name
   private _mutex = new SimplePromiseQueue()
@@ -56,7 +56,7 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
     this.key = ((options.key != null) ? options.key : 'vuex')
 
     this.committing = false;
-    this.mutationKey = 'vuex-shared-mutation'
+    this.keyMutation = options.keyMutation || 'vuex-shared-mutation'
 
     this.subscribed = false
     this.supportCircular = options.supportCircular || false
@@ -283,7 +283,7 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
 
           try {
             if (this.filterShared(mutation)) {
-              this.saveMutation(this.mutationKey, mutation, this.storage)
+              this.saveMutation(this.keyMutation, mutation, this.storage)
             }
             if (this.filter(mutation)) {
               this.saveState(this.key, this.reducer(state), this.storage)
@@ -297,7 +297,7 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
         if (options.sharedMutations != null || options.filterShared != null) {
           window.addEventListener('storage', event => {
             if (event.newValue === null) return;
-            if (event.key !== this.mutationKey) return;
+            if (event.key !== this.keyMutation) return;
 
             // console.log('event listener')
             // console.log(event)

--- a/src/index.ts
+++ b/src/index.ts
@@ -294,24 +294,26 @@ export class VuexPersistence<S, P extends Payload> implements PersistOptions<S> 
           }
         })
 
-        window.addEventListener('storage', event => {
-          if (event.newValue === null) return;
-          if (event.key !== this.mutationKey) return;
+        if (options.sharedMutations != null || options.filterShared != null) {
+          window.addEventListener('storage', event => {
+            if (event.newValue === null) return;
+            if (event.key !== this.mutationKey) return;
 
-          // console.log('event listener')
-          // console.log(event)
+            // console.log('event listener')
+            // console.log(event)
 
-          try {
-            const mutation = JSON.parse(event.newValue)
-            this.committing = true;
-            store.commit(mutation.type, mutation.payload);
-          } catch (error) {
-            console.error('[vuex-persist] Unable to parse shared mutation data');
-            console.error(event.newValue, error);
-          } finally {
-            this.committing = false;
-          }
-        })
+            try {
+              const mutation = JSON.parse(event.newValue)
+              this.committing = true;
+              store.commit(mutation.type, mutation.payload);
+            } catch (error) {
+              console.error('[vuex-persist] Unable to parse shared mutation data');
+              console.error(event.newValue, error);
+            } finally {
+              this.committing = false;
+            }
+          })
+        }
 
         this.subscribed = true
       }


### PR DESCRIPTION
Related to #29. 

Some issues need to be fix before merge. I don't know how to correctly handle them : 
- check if the plugin is in localStorage mode before addEventListener and saveMutation()
- add unit testing. We need to use independants stores with same localStorage in the test

We could support the feature in any storage mode by forcing use of localStorage in saveMutation. But it's easy to create an extra plugin who share mutations across stores and don't persist anything in localStorage.