### PR TITLE
Update nuxt (SSR) example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,12 +106,13 @@ export default {
 
 ```js
 // ~/plugins/vuex-persist.js
-import store from '~/store/'
 import VuexPersistence from 'vuex-persist'
 
-new VuexPersistence({
-  /* your options */
-}).plugin(store)
+export default ({store}) => {
+    return new VuexPersistence({
+        /* your options */
+    }).plugin(store);
+}
 ```
 
 ## Usage


### PR DESCRIPTION
`~/store` returns a function, not the actual store. We need the actual store instance to get it working.