### PR TITLE
Emit `vuexPersistStateRestored` event when async store replaced (addresses #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,13 +421,44 @@ You can note 2 differences here -
 1. All functions are asynchronous with Promises (because WebSQL and IndexedDB are async)
 2. It works on objects too (not just strings)
 
-I have made `vuex-persist` compatible with both types of storages, but this comes
-at a slight cost.
+I have made `vuex-persist` compatible with both types of storages, but this comes at a slight cost.
 When using asynchronous (promise-based) storages, your state will **not** be
 immediately restored into vuex from localForage. It will go into the event loop
 and will finish when the JS thread is empty. This can invoke a delay of few seconds.
-[Issue #15](https://github.com/championswimmer/vuex-persist/issues/15) of this repository explains
-what you can do to _find out_ when store has restored.
+
+### How to know when async store has been replaced
+
+As noted above, the store is not immediately restored from async stores like localForage. This can have the unfortunate side effect of overwriting mutations to the store that happen before `vuex-persist` has a chance to do its thing. In strict mode, you can create a plugin to subscribe to **`RESTORE_MUTATION`** so that you tell your app to wait until the state has been restored before committing any further mutations. ([Issue #15 demonstrates how to write such a plugin.](https://github.com/championswimmer/vuex-persist/issues/15)) However, since you should turn strict mode off in production, and since [`vuex` doesn't currently provide any kind of notification when `replaceState()` has been called](https://github.com/vuejs/vuex/issues/1316), starting with `v2.1.0` `vuex-persist` will emit a `vuexPersistStateRestored` event and also set as `vuexPersistStateRestored` flag to let you know the state has been restored and that it is now safe to commit any mutations that modify the stored state.
+
+Here's an example of a `beforeEach()` hook in `vuex-router` that will cause your app to wait for `vuex-persist` to restore the state before taking any further actions:
+
+```js
+// in src/router.js
+import Vue from 'vue'
+import Router from 'vue-router'
+import { store } from '@/store' // ...or wherever your `vuex` store is defined
+
+Vue.use(Router)
+
+const router = new Router({
+  // define your router as you normally would
+})
+
+const waitForStorageToBeReady = (to, from, next) => {
+  if (!store._vm.$root.$data['vuexPersistStateRestored']) {
+    store._vm.$root.$on('vuexPersistStateRestored', () => {
+      next()
+    })
+  } else {
+    next()
+  }
+}
+router.beforeEach(waitForStorageToBeReady)
+
+export default router
+```
+
+Note that `store._vm.$root.$data['vuexPersistStateRestored']` will be `undefined` and therefore "falsy" prior to being set to `true` by the `vuex-persist` plugin. There should be no need to explicitly give it a value at any point.
 
 ## Unit Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -983,6 +983,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1304,7 +1305,8 @@
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -1388,6 +1390,7 @@
           "version": "3.2.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1434,7 +1437,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -1700,7 +1704,8 @@
         "repeat-string": {
           "version": "1.6.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,16 @@ export class VuexPersistence<S> implements PersistOptions<S> {
        * @param {Store<S>} store
        */
       this.plugin = (store: Store<S>) => {
-        ((this.restoreState(this.key, this.storage)) as Promise<S>).then((savedState) => {
+        /**
+         * For async stores, we're capturing the Promise returned
+         * by the `restoreState()` function in a `restored` property
+         * on the store itself. This would allow app developers to
+         * determine when and if the store's state has indeed been
+         * refreshed. This approach was suggested by GitHub user @hotdogee.
+         * See https://github.com/championswimmer/vuex-persist/pull/118#issuecomment-500914963
+         * @since 2.1.0
+         */
+        (store as any).restored = ((this.restoreState(this.key, this.storage)) as Promise<S>).then((savedState) => {
           /**
            * If in strict mode, do only via mutation
            */
@@ -168,19 +177,6 @@ export class VuexPersistence<S> implements PersistOptions<S> {
           } else {
             store.replaceState(merge(store.state, savedState || {}))
           }
-
-          /**
-           * Notify the app that the state has been restored, and
-           * set a flag that can be used to prevent state restores
-           * from happening on other pages. (Note: this is one of
-           * those rare cases when semicolon is necessary since ASI
-           * won't insert one between two lines that end and begin
-           * with parentheses.)
-           * @since 2.1.0
-           */
-          (store as any)._vm.$root.$data['vuexPersistStateRestored'] = true;
-          (store as any)._vm.$root.$emit('vuexPersistStateRestored')
-
           this.subscriber(store)((mutation: MutationPayload, state: S) => {
             if (this.filter(mutation)) {
               this._mutex.enqueue(

--- a/src/index.ts
+++ b/src/index.ts
@@ -172,7 +172,7 @@ export class VuexPersistence<S> implements PersistOptions<S> {
           /**
            * Notify the app that the state has been restored, and
            * set a flag that can be used to prevent state restores
-           * from happening on other pages. (Note: this is one of 
+           * from happening on other pages. (Note: this is one of
            * those rare cases when semicolon is necessary since ASI
            * won't insert one between two lines that end and begin
            * with parentheses.)

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,18 @@ export class VuexPersistence<S> implements PersistOptions<S> {
             store.replaceState(merge(store.state, savedState || {}))
           }
 
+          /**
+           * Notify the app that the state has been restored, and
+           * set a flag that can be used to prevent state restores
+           * from happening on other pages. (Note: this is one of 
+           * those rare cases when semicolon is necessary since ASI
+           * won't insert one between two lines that end and begin
+           * with parentheses.)
+           * @since 2.1.0
+           */
+          (store as any)._vm.$root.$data['vuexPersistStateRestored'] = true;
+          (store as any)._vm.$root.$emit('vuexPersistStateRestored')
+
           this.subscriber(store)((mutation: MutationPayload, state: S) => {
             if (this.filter(mutation)) {
               this._mutex.enqueue(

--- a/test/async-plugin-emits-restored.spec.ts
+++ b/test/async-plugin-emits-restored.spec.ts
@@ -1,8 +1,7 @@
 /**
- * Created by morphatic on 23/05/19.
+ * Created by morphatic on 23/05/19. Updated 12/06/19.
  */
 
-import { expect } from 'chai'
 import localForage from 'localforage'
 import Vue from 'vue'
 import Vuex from 'vuex'
@@ -35,7 +34,7 @@ localForage.defineDriver(MockForageStorage as any)
 localForage.setDriver('objectStorage')
 
 const vuexPersist = new VuexPersistence<any>({
-  key: 'emit_test',
+  key: 'restored_test',
   asyncStorage: true,
   storage: localForage,
   reducer: (state) => ({ count: state.count })
@@ -53,19 +52,9 @@ const storeOpts = {
   plugins: [vuexPersist.plugin]
 }
 
-describe('Storage: AsyncStorage; Test: emit/flag on restore; Strict Mode: OFF', () => {
-  it('should emit `vuexPersistStateRestored` when async state is restored', (done) => {
-    const store = new Vuex.Store<any>(storeOpts);
-    (store as any)._vm.$root.$on('vuexPersistStateRestored', done)
-  })
-
-  it('should set the `vuexPersistStateRestored` flag when async state restored', (done) => {
-    const store = new Vuex.Store<any>(storeOpts);
-    (store as any)._vm.$root.$on('vuexPersistStateRestored', () => {
-      /* tslint:disable:no-unused-expression */
-      expect((store as any)._vm.$root.$data['vuexPersistStateRestored']).to.be.true
-      /* tslint:enable:no-unused-expression */
-      done()
-    })
+describe('Storage: AsyncStorage; Test: set `restored` on store; Strict Mode: OFF', () => {
+  it('connects the `store.restored` property to the Promise returned by `restoreState()`', (done) => {
+    const store: any = new Vuex.Store<any>(storeOpts);
+    store.restored.then(done)
   })
 })

--- a/test/async-plugin-emits-restored.spec.ts
+++ b/test/async-plugin-emits-restored.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Created by morphatic on 23/05/19.
+ */
+
+import { assert, expect, should } from 'chai'
+import localForage from 'localforage'
+import Vue from 'vue'
+import Vuex from 'vuex'
+import VuexPersistence from '..'
+
+const objectStore: {[key: string]: any} = {}
+const MockForageStorage = {
+  _driver: 'objectStorage',
+  _support: true,
+  _initStorage () {},
+  clear () {},
+  getItem<T> (key: string): Promise<T> {
+    return Promise.resolve<T>(objectStore[key])
+  },
+  iterate () {},
+  key () {},
+  keys () {},
+  length () {},
+  removeItem () {},
+  setItem<T> (key: string, data: T): Promise<T> {
+    return Promise.resolve<T>((objectStore[key] = data))
+  }
+}
+
+Vue.use(Vuex)
+
+localForage.defineDriver(MockForageStorage as any)
+localForage.setDriver('objectStorage')
+
+const vuexPersist = new VuexPersistence<any>({
+  key: 'emit_test',
+  asyncStorage: true,
+  storage: localForage,
+  reducer: state => ({ count: state.count })
+})
+
+const storeOpts = {
+  state: {
+    count: 0
+  },
+  mutations: {
+    increment (state) {
+      state.count++
+    }
+  },
+  plugins: [vuexPersist.plugin]
+}
+
+describe('Storage: AsyncStorage; Test: emit/flag on restore; Strict Mode: OFF', () => {
+  it('should emit `vuexPersistStateRestored` when async state is restored', done => {
+    const store = new Vuex.Store<any>(storeOpts);
+    (store as any)._vm.$root.$on('vuexPersistStateRestored', done)
+  })
+
+  it('should set the `vuexPersistStateRestored` flag when async state restored', done => {
+    const store = new Vuex.Store<any>(storeOpts);
+    (store as any)._vm.$root.$on('vuexPersistStateRestored', () => {
+      expect((store as any)._vm.$root.$data['vuexPersistStateRestored']).to.be.true
+      done()
+    })
+  })
+})

--- a/test/async-plugin-emits-restored.spec.ts
+++ b/test/async-plugin-emits-restored.spec.ts
@@ -2,30 +2,32 @@
  * Created by morphatic on 23/05/19.
  */
 
-import { assert, expect, should } from 'chai'
+import { expect } from 'chai'
 import localForage from 'localforage'
 import Vue from 'vue'
 import Vuex from 'vuex'
 import VuexPersistence from '..'
 
 const objectStore: {[key: string]: any} = {}
+/* tslint:disable:no-empty */
 const MockForageStorage = {
   _driver: 'objectStorage',
   _support: true,
-  _initStorage () {},
-  clear () {},
-  getItem<T> (key: string): Promise<T> {
+  _initStorage() {},
+  clear() {},
+  getItem<T>(key: string): Promise<T> {
     return Promise.resolve<T>(objectStore[key])
   },
-  iterate () {},
-  key () {},
-  keys () {},
-  length () {},
-  removeItem () {},
-  setItem<T> (key: string, data: T): Promise<T> {
+  iterate() {},
+  key() {},
+  keys() {},
+  length() {},
+  removeItem() {},
+  setItem<T>(key: string, data: T): Promise<T> {
     return Promise.resolve<T>((objectStore[key] = data))
   }
 }
+/* tslint:enable:no-empty */
 
 Vue.use(Vuex)
 
@@ -36,7 +38,7 @@ const vuexPersist = new VuexPersistence<any>({
   key: 'emit_test',
   asyncStorage: true,
   storage: localForage,
-  reducer: state => ({ count: state.count })
+  reducer: (state) => ({ count: state.count })
 })
 
 const storeOpts = {
@@ -52,12 +54,12 @@ const storeOpts = {
 }
 
 describe('Storage: AsyncStorage; Test: emit/flag on restore; Strict Mode: OFF', () => {
-  it('should emit `vuexPersistStateRestored` when async state is restored', done => {
+  it('should emit `vuexPersistStateRestored` when async state is restored', (done) => {
     const store = new Vuex.Store<any>(storeOpts);
     (store as any)._vm.$root.$on('vuexPersistStateRestored', done)
   })
 
-  it('should set the `vuexPersistStateRestored` flag when async state restored', done => {
+  it('should set the `vuexPersistStateRestored` flag when async state restored', (done) => {
     const store = new Vuex.Store<any>(storeOpts);
     (store as any)._vm.$root.$on('vuexPersistStateRestored', () => {
       expect((store as any)._vm.$root.$data['vuexPersistStateRestored']).to.be.true

--- a/test/async-plugin-emits-restored.spec.ts
+++ b/test/async-plugin-emits-restored.spec.ts
@@ -46,7 +46,7 @@ const storeOpts = {
     count: 0
   },
   mutations: {
-    increment (state) {
+    increment(state) {
       state.count++
     }
   },
@@ -62,7 +62,9 @@ describe('Storage: AsyncStorage; Test: emit/flag on restore; Strict Mode: OFF', 
   it('should set the `vuexPersistStateRestored` flag when async state restored', (done) => {
     const store = new Vuex.Store<any>(storeOpts);
     (store as any)._vm.$root.$on('vuexPersistStateRestored', () => {
+      /* tslint:disable:no-unused-expression */
       expect((store as any)._vm.$root.$data['vuexPersistStateRestored']).to.be.true
+      /* tslint:enable:no-unused-expression */
       done()
     })
   })

--- a/test/async-plugin-emits-restored.spec.ts
+++ b/test/async-plugin-emits-restored.spec.ts
@@ -54,7 +54,7 @@ const storeOpts = {
 
 describe('Storage: AsyncStorage; Test: set `restored` on store; Strict Mode: OFF', () => {
   it('connects the `store.restored` property to the Promise returned by `restoreState()`', (done) => {
-    const store: any = new Vuex.Store<any>(storeOpts);
+    const store: any = new Vuex.Store<any>(storeOpts)
     store.restored.then(done)
   })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "outDir": "dist",
+    "declaration": true,
     "declarationDir": "dist/types",
     "noImplicitReturns": true,
     "noImplicitAny": true,


### PR DESCRIPTION
Addresses [issue raised in issue 15](https://github.com/championswimmer/vuex-persist/issues/15#issuecomment-424078088) by @rulrok. Also addresses #56. Supersedes #107.

This PR contains updated `index.ts` as well as `README.md` to update the documentation on how to use the new event. New functionality is tested in `test/async-plugin-emits-restored.spec.ts`.

As [noted in the docs](https://github.com/championswimmer/vuex-persist#note-on-localforage and-async-stores), the store is not immediately restored from async stores like `localForage`. This can have the unfortunate side effect of overwriting mutations to the store that happen before `vuex-persist` has a chance to do its thing. In strict mode, you can create a plugin to subscribe to **`RESTORE_MUTATION`** so that you tell your app to wait until the state has been restored before committing any further mutations. ([Issue #15 demonstrates how to write such a plugin.](https://github.com/championswimmer/vuex-persist/issues/15)) However, since you should turn strict mode off in production, and since [`vuex` doesn't currently provide any kind of notification when `replaceState()` has been called](https://github.com/vuejs/vuex/issues/1316), this PR would cause `vuex-persist` to emit a `vuexPersistStateRestored` event and also set a `vuexPersistStateRestored` flag to let you know the state has been restored and that it is now safe to commit any mutations that modify the stored state.

Here's an example of a `beforeEach()` hook in `vuex-router` that will cause your app to wait for `vuex-persist` to restore the state before taking any further actions:

```js
// in src/router.js
import Vue from 'vue'
import Router from 'vue-router'
import { store } from '@/store' // ...or wherever your `vuex` store is defined

Vue.use(Router)

const router = new Router({
  // define your router as you normally would
})

const waitForStorageToBeReady = (to, from, next) => {
  if (!store._vm.$root.$data['vuexPersistStateRestored']) {
    store._vm.$root.$on('vuexPersistStateRestored', () => {
      next()
    })
  } else {
    next()
  }
}
router.beforeEach(waitForStorageToBeReady)

export default router
```

Note: `store._vm.$root.$data['vuexPersistStateRestored']` will be `undefined` and therefore "falsy" prior to being set to `true` by the `vuex-persist` plugin. There should be no need to explicitly give it a value at any point.