### PR TITLE
Fixes #97: localForage object stored as string when using custom name

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Some of the most popular ways to persist your store would be -
 - **[js-cookie](https://npmjs.com/js-cookie)** to use browser Cookies
 - **window.localStorage** (remains, across PC reboots, untill you clear browser data)
 - **window.sessionStorage** (vanishes when you close browser tab)
-- **[localForage](http://npmjs.com/localForage)** Uses IndexedDB from the browser
+- **[localForage](http://npmjs.com/localforage)** Uses IndexedDB from the browser
 
 ### Note on LocalForage and async stores
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,8 +104,8 @@ export class VuexPersistence<S> implements PersistOptions<S> {
     }
 
     this.asyncStorage = options.asyncStorage || false
-    const storageConfig = this.storage && ((this.storage) as any)._config
-    this.asyncStorage = this.asyncStorage || (storageConfig && storageConfig.name) === 'localforage'
+    const storageConstructor = this.storage && this.storage.constructor && this.storage.constructor.name.toLowerCase()
+    this.asyncStorage = this.asyncStorage || storageConstructor === 'localforage'
 
     if (this.asyncStorage) {
 
@@ -142,7 +142,7 @@ export class VuexPersistence<S> implements PersistOptions<S> {
           : ((key: string, state: {}, storage: AsyncStorage) =>
               (storage).setItem(
                 key, // Second argument is state _object_ if localforage, stringified otherwise
-                (((storage && storage._config && storage._config.name) === 'localforage')
+                (((storage && storage.constructor && storage.constructor.name.toLowerCase()) === 'localforage')
                     ? merge({}, state || {})
                     : (
                       this.supportCircular


### PR DESCRIPTION
* root cause: when checking if the storage was using localforage, the check was based on the DB name and assumed it would always be the default name.
* solution: rather than checking the DB name (which is configurable), instead check the constructor type
* bonus fix: npm URLs are case sensitive, fixing type-o in npm URL to localforage