### PR TITLE
Remove manual checks for "localforage", always rely on value of…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Cookies or localStorage.
     - [Tips for NUXT](#tips-for-nuxt)
   - [Usage](#usage)
     - [Steps](#steps)
-    - [Constructor Parameters -](#constructor-parameters--)
+    - [Constructor Parameters -](#constructor-parameters)
     - [Usage Notes](#usage-notes)
       - [Reducer](#reducer)
       - [Circular States](#circular-states)
@@ -46,6 +46,7 @@ Cookies or localStorage.
     - [Detailed](#detailed)
     - [Support Strict Mode](#support-strict-mode)
     - [Note on LocalForage and async stores](#note-on-localforage-and-async-stores)
+    - [How to know when async store has been replaced](#how-to-know-when-async-store-has-been-replaced)
   - [Unit Testing](#unit-testing)
     - [Jest](#jest)
 
@@ -208,8 +209,8 @@ Here are the properties, and what they mean -
 | reducer         | function<br> (state) => object         | State reducer. reduces state to only those values you want to save. <br>By default, saves entire state                                                                               |
 | filter          | function<br> (mutation) => boolean     | Mutation filter. Look at `mutation.type` and return true <br>for only those ones which you want a persistence write to be triggered for. <br> Default returns true for all mutations |
 | modules         | string[]                               | List of modules you want to persist. (Do not write your own reducer if you want to use this)                                                                                         |
-| asyncStorage    | boolean                                | Denotes if the store uses Promises (like localforage) or not <br>_**Default: false**_                                                                                                |
-| supportCircular | boolean                                | Denotes if the state has any circular references to itself (state.x === state)                                                                                                       |
+| asyncStorage    | boolean                                | Denotes if the store uses Promises (like localforage) or not (you must set this to true when suing something like localforage) <br>_**Default: false**_                                                                                                |
+| supportCircular | boolean                                | Denotes if the state has any circular references to itself (state.x === state) <br>_**Default: false**_                                                                                                       |
 
 ### Usage Notes
 

--- a/src/PersistOptions.ts
+++ b/src/PersistOptions.ts
@@ -63,7 +63,7 @@ export interface PersistOptions<S> {
   /**
    * If your storage is async
    * i.e., if setItem(), getItem() etc return Promises
-   * (Should be used for storages like LocalForage)
+   * (Must be used for asynchronous storages like LocalForage)
    * @default false
    */
   asyncStorage?: boolean

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,8 +104,6 @@ export class VuexPersistence<S> implements PersistOptions<S> {
     }
 
     this.asyncStorage = options.asyncStorage || false
-    const storageConstructor = this.storage && this.storage.constructor && this.storage.constructor.name.toLowerCase()
-    this.asyncStorage = this.asyncStorage || storageConstructor === 'localforage'
 
     if (this.asyncStorage) {
 
@@ -141,8 +139,9 @@ export class VuexPersistence<S> implements PersistOptions<S> {
           ? options.saveState
           : ((key: string, state: {}, storage: AsyncStorage) =>
               (storage).setItem(
-                key, // Second argument is state _object_ if localforage, stringified otherwise
-                (((storage && storage.constructor && storage.constructor.name.toLowerCase()) === 'localforage')
+                key, // Second argument is state _object_ if asyc storage, stringified otherwise
+                // do not stringify the state if the storage type is async
+                (this.asyncStorage
                     ? merge({}, state || {})
                     : (
                       this.supportCircular

--- a/test/vuex-asyncstorage.spec.ts
+++ b/test/vuex-asyncstorage.spec.ts
@@ -35,6 +35,7 @@ localForage.setDriver('objectStorage')
 
 const vuexPersist = new VuexPersistence<any>({
   storage: localForage,
+  asyncStorage: true,
   key: 'dafuq',
   reducer: (state) => ({ dog: state.dog }),
   filter: (mutation) => (mutation.type === 'dogBark')


### PR DESCRIPTION
# What problem does this solve?
* checking `storage.name` is unreliable, because that value can be customized by the user (ref #97)
* checking `storage.constructor.name` is also unreliable since it will be undefined in IE11 (ref #138)
* doing a string-based check for "localforage" is also unreliable because when the application code is minified the constructor name will be different (ref #144)

# How does it solve it?
any manual checks for "localforage" have been removed. these were only being used as an attempt to automatically determine if the storage type of async or not. but trying to do so automatically has proven to be extremely unreliable. so instead the code now only uses the value of the `asyncStorage` config object.

# What impact does this have?
this means that if any consumer of this plugin who is using localforage must explicitly set the `asyncStorage` option is the config object.
(the README has been updated to reflect this)

closes #138
closes #144
closes #147