### PR TITLE
fix: example breaks functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,11 +137,9 @@ export default {
 import VuexPersistence from 'vuex-persist'
 
 export default ({ store }) => {
-  window.onNuxtReady(() => {
-    new VuexPersistence({
-    /* your options */
-    }).plugin(store);
-  });
+  new VuexPersistence({
+  /* your options */
+  }).plugin(store);
 }
 ```
 


### PR DESCRIPTION
vuex-persist restoration breaks because of `window.onNuxtReady` as reported in #119.

A lot of people may fall prey to this broken example. Its also a bit tricky to debug.