### PR TITLE
Fix this.mergeOption being null in RESTORE_MUTATION in strictmode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,8 +104,9 @@ export class VuexPersistence<S> implements PersistOptions<S> {
 
     this.strictMode = options.strictMode || false
 
+    var _this = this
     this.RESTORE_MUTATION = function RESTORE_MUTATION(state: S, savedState: any) {
-      const mergedState = merge(state, savedState || {}, this.mergeOption)
+      const mergedState = merge(state, savedState || {}, _this.mergeOption)
       for (const propertyName of Object.keys(mergedState as {})) {
         (this as any)._vm.$set(state, propertyName, (mergedState as any)[propertyName])
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ export class VuexPersistence<S> implements PersistOptions<S> {
 
     this.strictMode = options.strictMode || false
 
-    var _this = this
+    const _this = this
     this.RESTORE_MUTATION = function RESTORE_MUTATION(state: S, savedState: any) {
       const mergedState = merge(state, savedState || {}, _this.mergeOption)
       for (const propertyName of Object.keys(mergedState as {})) {


### PR DESCRIPTION
Fix for issue #213, where I think the issue is explained best, but I'll give it my own try below

`RESTORE_MUTATION` function contains a reference to `this.mergeOption`, but `this` seems to be for a different context, causing mergeOption to always be null when using the `RESTORE_MUTATION`

This creates an issue when restoring arrays from localStorage. Deepmerge defaults to a merge behaviour when merging arrays, but vuex-persist defaults to 'replaceArrays', which ends up not being respected as mergeOption is null, so Deepmerge reverts to it's default of merging arrays.

I've put together an example of the issue in action [here](https://codesandbox.io/s/small-https-sk1g5?file=/src/main.js)

Thanks