### PR TITLE
Make the async queue a queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuex-persist",
-  "version": "3.1.3",
+  "version": "3.1.4-propel",
   "description": "A Vuex persistence plugin in Typescript",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/src/SimplePromiseQueue.ts
+++ b/src/SimplePromiseQueue.ts
@@ -1,10 +1,10 @@
 // tslint:disable: variable-name
 export default class SimplePromiseQueue {
-  private readonly _queue: Array<Promise<void>> = []
+  private readonly _queue: Array<() => Promise<void>> = []
   private _flushing = false
 
-  public enqueue(promise: Promise<void>) {
-    this._queue.push(promise)
+  public enqueue(task: () => Promise<void>) {
+    this._queue.push(task)
     if (!this._flushing) { return this.flushQueue() }
     return Promise.resolve()
   }
@@ -15,7 +15,7 @@ export default class SimplePromiseQueue {
     const chain = (): Promise<void> | void => {
       const nextTask = this._queue.shift()
       if (nextTask) {
-        return nextTask.then(chain)
+        return nextTask().then(chain)
       } else {
         this._flushing = false
       }

--- a/test/vuex-async-queue.spec.ts
+++ b/test/vuex-async-queue.spec.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai'
+import Vue from 'vue'
+import { Store } from 'vuex'
+import Vuex from 'vuex'
+import VuexPersistence from '..'
+
+Vue.use(Vuex)
+
+class SaveWaiter {
+  ready: Promise<void>
+  done: Promise<void>
+  resolveReady!: () => void
+  resolveDone!: () => void
+
+  constructor() {
+    this.ready = new Promise((resolve) => { this.resolveReady = resolve })
+    this.done = new Promise((resolve) => { this.resolveDone = resolve })
+  }
+}
+
+const KEY = 'key'
+const storage: Record<string, any> = {}
+const saveWaiters = [new SaveWaiter(), new SaveWaiter()]
+let saveCount = 0
+const vuexPersist = new VuexPersistence({
+  key: KEY,
+  asyncStorage: true,
+  restoreState: async (key) => storage[key],
+  saveState: async (key, state) => {
+    const saveWaiter = saveWaiters[saveCount]
+    saveCount++
+
+    await saveWaiter.ready
+    storage[key] = state
+    saveWaiter.resolveDone()
+  }
+})
+
+const store = new Store<any>({
+  state: {
+    dog: {
+      barks: 0
+    },
+    cat: {
+      mews: 0
+    }
+  },
+  mutations: {
+    dogBark(state) {
+      state.dog.barks++
+    },
+    catMew(state) {
+      state.cat.mews++
+    }
+  },
+  plugins: [vuexPersist.plugin]
+})
+
+describe('Storage: Custom/Async; Test: queue order', () => {
+  it('should wait for the previous save to finish before saving', async () => {
+    store.commit('dogBark')
+    store.commit('catMew')
+
+    // Make the second saveWaiter ready first. This should do nothing, because the write sits in
+    // the queue behind the first write. The await here is needed to make the expect fail if
+    // saveState has already started execution by making the promise in saveState resolve.
+    saveWaiters[1].resolveReady()
+    await saveWaiters[1].ready
+    expect(storage[KEY]).not.to.exist
+
+    saveWaiters[0].resolveReady()
+    await saveWaiters[0].done
+    expect(storage[KEY]).to.deep.equal({ dog: { barks: 1 }, cat: { mews: 0 }})
+
+    await saveWaiters[1].done
+    expect(storage[KEY]).to.deep.equal({ dog: { barks: 1 }, cat: { mews: 1 }})
+  })
+})


### PR DESCRIPTION
Right now all promises are started immediately, so the writes can happen in the wrong order. This enforces the order of the writes by making each item in the queue a function which we only execute when it reaches the front of the queue. We also modify the default reducer to make a copy of the state, so each saveState call will have a snapshot of the state instead of the global object that can be modified.