### PR TITLE
Allow all deepmerge.Options to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ Here are the properties, and what they mean -
 | modules         | string[]                               | List of modules you want to persist. (Do not write your own reducer if you want to use this)                                                                                         |
 | asyncStorage    | boolean                                | Denotes if the store uses Promises (like localforage) or not (you must set this to true when using something like localforage) <br>_**Default: false**_                                                                                                |
 | supportCircular | boolean                                | Denotes if the state has any circular references to itself (state.x === state) <br>_**Default: false**_                                                                                                       |
+| mergeOption     | String or deepmerge Options | By default, when merging previous state with the new state, arrays are replaced. <br>You can pass 'concatArrays' to concatenate them instead.<br>Additionally, you can pass through whatever deepmerge.Options you want. <br>_**Default: 'replaceArrays'**_                                                                                                       |
 
 ### Usage Notes
 
@@ -255,6 +256,35 @@ And when constructing the store, add `supportCircular` flag
 new VuexPersistence({
   supportCircular: true,
   ...
+})
+```
+
+#### Non-Plain objects in the store
+
+If you have non-plain objects in your store, you need to provide a way to identify them via the `mergeOption`.
+
+Otherwise, they will be turned into plain objects.
+
+```js
+import Vue from 'vue'
+import Vuex from 'vuex'
+import VuexPersistence from 'vuex-persist'
+import { replaceArrays } from 'vuex-persist'
+import { isPlainObject } from 'is-plain-object';
+
+Vue.use(Vuex)
+
+var store = new Vuex.Store({
+  state: {
+    user: new User('arny'), 
+    navigation: { path: '/home' }
+  },
+  plugins: [new VuexPersistence({
+    mergeOption: {
+      isMergeableObject: isPlainObject,
+      arrayMerge: replaceArrays  
+    }
+  }).plugin]
 })
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { AsyncStorage } from './AsyncStorage'
 import { MockStorage } from './MockStorage'
 import { PersistOptions } from './PersistOptions'
 import SimplePromiseQueue from './SimplePromiseQueue'
-import { merge, MergeOptionType } from './utils'
+import { merge, MergeOptionType, replaceArrays, concatArrays } from './utils'
 
 let FlattedJSON = JSON
 
@@ -279,7 +279,7 @@ export class VuexPersistence<S> implements PersistOptions<S> {
 }
 
 export {
-  MockStorage, AsyncStorage, PersistOptions
+  MockStorage, AsyncStorage, PersistOptions, MergeOptionType, replaceArrays, concatArrays
 }
 
 export default VuexPersistence

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,21 +1,23 @@
 import deepmerge from 'deepmerge'
 
-export type MergeOptionType = 'replaceArrays' | 'concatArrays'
+export type MergeOptionType = 'replaceArrays' | 'concatArrays' | deepmerge.Options
 
-const options: {[k in MergeOptionType]: deepmerge.Options} = {
+export const replaceArrays = (destinationArray: any[], sourceArray: any[], options:deepmerge.Options) => sourceArray
+export const concatArrays = (target: any[], source: any[], options:deepmerge.Options) => target.concat(...source)
+
+const stringOptions = {
   replaceArrays: {
-    arrayMerge: (destinationArray, sourceArray, options) => sourceArray
+    arrayMerge: replaceArrays
   },
   concatArrays: {
-    arrayMerge: (target, source, options) => target.concat(...source)
+    arrayMerge: concatArrays
   }
 }
 
-const defaultMergeOptions: deepmerge.Options = {
-  // replacing arrays
-  
-}
-
 export function merge<I, F>(into: Partial<I>, from: Partial<F>, mergeOption: MergeOptionType): I & F & {} {
-  return deepmerge(into, from, options[mergeOption])
+  if (typeof mergeOption == 'string') {
+      return deepmerge(into, from, stringOptions[mergeOption])
+  } else {
+      return deepmerge(into, from, mergeOption)
+  }
 }


### PR DESCRIPTION
This is just a proof of concept to cover issues with custom object types being converted to plain objects. See
https://www.npmjs.com/package/deepmerge#ismergeableobject for how they describe the issue.

Using this fixes #216 (see example in README.md).

I have never used TS before, so I'm sure I've done some things wrong, I just wanted to show how it could be fixed.